### PR TITLE
Fix memory leak by properly closing charsetDetector

### DIFF
--- a/icuWrapper.cpp
+++ b/icuWrapper.cpp
@@ -28,6 +28,7 @@ NAN_METHOD(DetectCharacterEncoding) {
 
 	if(U_FAILURE(errorCode)) {
 		Nan::ThrowError("Failed to set ICU charset detector’s text.");
+		ucsdet_close(charsetDetector);
 		return;
 	}
 
@@ -35,6 +36,7 @@ NAN_METHOD(DetectCharacterEncoding) {
 
 	if(U_FAILURE(errorCode)) {
 		Nan::ThrowError("Failed to detect charset.");
+		ucsdet_close(charsetDetector);
 		return;
 	}
 
@@ -42,6 +44,7 @@ NAN_METHOD(DetectCharacterEncoding) {
 
 	if(U_FAILURE(errorCode)) {
 		Nan::ThrowError("Failed to get name from charset match.");
+		ucsdet_close(charsetDetector);
 		return;
 	}
 
@@ -49,6 +52,7 @@ NAN_METHOD(DetectCharacterEncoding) {
 
 	if(U_FAILURE(errorCode)) {
 		Nan::ThrowError("Failed to get confidence from charset match.");
+		ucsdet_close(charsetDetector);
 		return;
 	}
 
@@ -57,6 +61,7 @@ NAN_METHOD(DetectCharacterEncoding) {
 	obj->Set(Nan::New<v8::String>("confidence").ToLocalChecked(), Nan::New<v8::Number>(confidence));
 
 	info.GetReturnValue().Set(obj);
+	ucsdet_close(charsetDetector);
 }
 
 void Init(v8::Local<v8::Object> exports) {


### PR DESCRIPTION
Hi,

we detected a memory issue with the latest version of detect-character-encoding and found that the documentation of ucsdet_close specifically mentions:

(see: http://icu-project.org/apiref/icu4c/ucsdet_8h.html#a84dab4d2c56fedb624a01db170ba698c)

Close a charset detector. All storage and any other resources owned by this charset detector will be released. Failure to close a charset detector when finished with it can result in memory leaks in the application.

I tried my hand at fixing the issue. From what I could see, the code change fixed the leak.

Because Nan:ThrowError does not seem to break the execution order of the code in this file, and ucsdet_open returns a null pointer in case of failure, it ought to be enough to close the charsetDetector at the end if it is not a nullptr and therefore was created successfully.

Regards,

Michael
